### PR TITLE
Only delete fallback trigger after successfully creating the new one

### DIFF
--- a/dist/Code.gs
+++ b/dist/Code.gs
@@ -587,7 +587,7 @@ function createTrigger(functionName, minutes) {
         .everyHours(1)
         .create();
     }
-    deleteTrigger(functionName, (exclude = newTrigger.getUniqueId()));
+    deleteTrigger(functionName, newTrigger.getUniqueId());
   } else {
     deleteTrigger(functionName);
     ScriptApp.newTrigger(functionName)

--- a/src/lib/helper/createTrigger.js
+++ b/src/lib/helper/createTrigger.js
@@ -24,7 +24,7 @@ function createTrigger(functionName, minutes) {
         .everyHours(1)
         .create();
     }
-    deleteTrigger(functionName, (exclude = newTrigger.getUniqueId()));
+    deleteTrigger(functionName, newTrigger.getUniqueId());
   } else {
     deleteTrigger(functionName);
     ScriptApp.newTrigger(functionName)

--- a/src/lib/helper/createTrigger.js
+++ b/src/lib/helper/createTrigger.js
@@ -1,5 +1,4 @@
 function createTrigger(functionName, minutes) {
-  deleteTrigger(functionName);
   if (functionName === "startFallback") {
     // Ceil to next valid interval (1, 5, 10, 15 or 30)
     minutes =
@@ -12,15 +11,22 @@ function createTrigger(functionName, minutes) {
             : minutes > 5
               ? 10
               : 5;
+
+    let newTrigger = null;
     if (minutes <= 30) {
-      ScriptApp.newTrigger(functionName)
+      newTrigger = ScriptApp.newTrigger(functionName)
         .timeBased()
         .everyMinutes(minutes)
         .create();
     } else {
-      ScriptApp.newTrigger(functionName).timeBased().everyHours(1).create();
+      newTrigger = ScriptApp.newTrigger(functionName)
+        .timeBased()
+        .everyHours(1)
+        .create();
     }
+    deleteTrigger(functionName, (exclude = newTrigger.getUniqueId()));
   } else {
+    deleteTrigger(functionName);
     ScriptApp.newTrigger(functionName)
       .timeBased()
       .after(minutes * 60 * 1000)

--- a/src/lib/helper/deleteTrigger.js
+++ b/src/lib/helper/deleteTrigger.js
@@ -1,7 +1,10 @@
-function deleteTrigger(functionName) {
+function deleteTrigger(functionName, exclude = null) {
   let triggers = ScriptApp.getProjectTriggers();
   for (let trigger of triggers) {
-    if (trigger.getHandlerFunction() === functionName) {
+    if (
+      trigger.getHandlerFunction() === functionName &&
+      trigger.getUniqueId() !== exclude
+    ) {
       ScriptApp.deleteTrigger(trigger);
       Logger.log(`Existing trigger deleted for the ${functionName}() function`);
     }


### PR DESCRIPTION
Context here: https://github.com/scriptPilot/google-calendar-synchronization/issues/20

This seems to work as I had a case where the new trigger creation failed (`ScriptApp.newTrigger`) and script execution aborted, but since we now keep the old trigger around it was able to recover without manual intervention:
<img width="3216" height="378" alt="2025-07-30 at 12 59 24@2x" src="https://github.com/user-attachments/assets/4354ebe6-c226-4cf5-b930-f380dbeba9df" />

Note I didn't use clasp or any of the tooling suggested in the dev readme, just `npm run build`